### PR TITLE
Updated dependencies, made path name unique.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,28 +16,32 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>0.8.7</version>
+            <version>1.0.8</version>
         </dependency>
         <dependency>
             <groupId>cascading</groupId>
             <artifactId>cascading-core</artifactId>
-            <version>1.2.4</version>
+            <version>1.2.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-core</artifactId>
-            <version>0.20.2-cdh3u2</version>
+            <version>1.0.1</version>
         </dependency>
         <dependency>
             <groupId>me.prettyprint</groupId>
             <artifactId>hector-core</artifactId>
-            <version>0.8.0-3</version>
+            <version>1.0-3</version>
         </dependency>
     </dependencies>
     <repositories>
       <repository>
         <id>cloudera</id>
         <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+      </repository>
+      <repository>
+        <id>conjars.org</id>
+        <url>http://conjars.org/repo</url>
       </repository>
     </repositories>
 

--- a/src/main/java/org/pingles/cascading/cassandra/CassandraTap.java
+++ b/src/main/java/org/pingles/cascading/cassandra/CassandraTap.java
@@ -15,6 +15,7 @@ import org.pingles.cascading.cassandra.hadoop.ColumnFamilyInputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
+import java.util.UUID;
 
 public class CassandraTap extends Tap {
     private static final Logger LOGGER =
@@ -26,6 +27,7 @@ public class CassandraTap extends Tap {
 
     private final String initialAddress;
     private final Integer rpcPort;
+    private final String pathUUID;
     private String columnFamilyName;
     private String keyspace;
 
@@ -36,6 +38,7 @@ public class CassandraTap extends Tap {
         this.rpcPort = null;
         this.columnFamilyName = columnFamilyName;
         this.keyspace = keyspace;
+	this.pathUUID = java.util.UUID.randomUUID().toString();
     }
 
 
@@ -47,6 +50,7 @@ public class CassandraTap extends Tap {
         this.rpcPort = rpcPort;
         this.columnFamilyName = columnFamilyName;
         this.keyspace = keyspace;
+	this.pathUUID = java.util.UUID.randomUUID().toString();
     }
 
     @Override
@@ -88,7 +92,7 @@ public class CassandraTap extends Tap {
         }
     }
 
-    protected String getStringPath() {
+    protected String getStringURI() {
         String host = (initialAddress != null)
             ? String.format("%s:%s", initialAddress, rpcPort) : "";
         return String.format("%s://%s/%s/%s",
@@ -97,14 +101,15 @@ public class CassandraTap extends Tap {
 
     @Override
     public Path getPath() {
-        return new Path(getStringPath());
+        return new Path(pathUUID);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName()
             + "[\"" + URI_SCHEME + "\"]"
-            + "[\"" + Util.sanitizeUrl(getStringPath()) + "\"]";
+            + "[\"" + Util.sanitizeUrl(getStringURI()) + "\"]"
+            + "[\"" + pathUUID + "\"]";
     }
 
     @Override
@@ -115,13 +120,13 @@ public class CassandraTap extends Tap {
 
         CassandraTap tap = (CassandraTap) obj;
         if (!getScheme().equals(tap.getScheme())) return false;
-        return getStringPath().equals(tap.getStringPath());
+        return getStringURI().equals(tap.getStringURI());
     }
 
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + getStringPath().hashCode();
+        result = 31 * result + getStringURI().hashCode();
         return result;
     }
 


### PR DESCRIPTION
I updated the dependences, and made path names unique.  If you open more than one tap to the same CF you got error messages about the need for path names to be unique.  I asked about this error message on the cascalog google group https://groups.google.com/d/topic/cascalog-user/IfbgkXJuBhc/discussion and Nathan stated that the path must be unique, but if you're not using it, which we aren't you are free to choose a random string.  I modified the code base to use a random UUID, which solves the problem.
