### PR TITLE
Fix ordering of values returned by NarrowRowScheme

### DIFF
--- a/src/main/java/org/pingles/cascading/cassandra/NarrowRowScheme.java
+++ b/src/main/java/org/pingles/cascading/cassandra/NarrowRowScheme.java
@@ -82,9 +82,16 @@ public class NarrowRowScheme extends CassandraScheme {
         if (this.keyField != null) {
             tuple.add((ByteBuffer) key);
         }
-        for (IColumn col: values.values()) {
-            tuple.add(col.value());
-        }
+
+		for (Comparable k: this.nameFields) {
+			IColumn v = values.get(TypeInferringSerializer.get().toByteBuffer(k));
+			if (v != null) {
+				tuple.add(v.value());
+			}
+			else {
+				tuple.add(null);
+			}
+		}
 
         return tuple;
     }


### PR DESCRIPTION
The sorted map used to store values comming back from C\* was sorted by key order, not the order by which the keys were requested.  We now populate the tuple using the order specified by the Fields passed during initiation of the NarrowRowScheme.  Fixes gh-5.
